### PR TITLE
Small syntax error

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ then
     fi
     gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
     
-    if [ ! -z "CLOUDSDK_CONTAINER_CLUSTER" ]
+    if [ ! -z "$CLOUDSDK_CONTAINER_CLUSTER" ]
     then
         gcloud container clusters get-credentials $CLOUDSDK_CONTAINER_CLUSTER
         docker-credential-gcr configure-docker


### PR DESCRIPTION
Missing "$" in variable name, if empty it is throwing an error as cluster name for "get-credentials" not provided.